### PR TITLE
make topbar sticky when using composer on mobile

### DIFF
--- a/client/organizer/TopBar.js
+++ b/client/organizer/TopBar.js
@@ -20,12 +20,12 @@ import { ChevronDown, ChevronUp, Close, ArrowLeft } from '@carbon/icons-react';
 
 const global_toolbarAction = new ObservableValue(null);
 
-export function TopBar() {
+export function TopBar({makeSticky}) {
     const s = TopBarStyle;
     const instanceKey = useInstanceKey();
     const toolbarAction = useObservable(global_toolbarAction);
     const datastore = useDatastore();
-    return <View style={s.topBox}>        
+    return <View style={[s.topBox, makeSticky && s.sticky]}>        
         <View style={s.leftRow}>    
             {historyGetState() ? 
                 <BreadCrumb icon={ArrowLeft} iconProps={{size:32}} onPress={() => datastore.goBack()} />
@@ -55,6 +55,13 @@ const TopBarStyle = StyleSheet.create({
         borderBottomWidth: StyleSheet.hairlineWidth,
         backgroundColor: 'white',
         height: 56
+    },
+    sticky: {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        zIndex: 1000,
     },
     leftRow: {
         flexDirection: 'row',

--- a/client/util/instance.js
+++ b/client/util/instance.js
@@ -13,6 +13,7 @@ import { useFirebaseData, useFirebaseUser } from './firebase';
 import { useIsAdminForSilo } from '../component/admin';
 import { goBack } from './navigate';
 import { requireParams } from './util';
+import { getDeviceInfo } from '../platform-specific/deviceinfo';
 
 export function useStandardFonts() {
     let [fontsLoaded] = useFonts({
@@ -143,9 +144,11 @@ export function StackedScreen({screenSet, screenInstance, index, features}) {
         }
         return null;
     }
+    
+    const {isMobile} = getDeviceInfo();
 
     return <FullScreen zIndex={index}>
-        {showTopBar && <TopBar title={title} index={index} params={params} subtitle={structure.name} />}
+        {showTopBar && <TopBar makeSticky={(screenKey === 'composer') && isMobile} />}
         <WaitForData>
             <Catcher>
                 {React.createElement(screen, params)}


### PR DESCRIPTION
Fixes Issue #113 (https://github.com/wearenewpublic/psi-product/issues/113)

Applies the absolute styling to the TopBar only for mobile on the composer screen. If we don't use these conditions, then we have to solve the problem of the content sliding underneath the topbar everywhere across the app.

I showed Tori this video of the change and she approved:
https://drive.google.com/file/d/1S4dHqcV3tnRIjLikoluFA7S5bTlqwtBi/view?usp=sharing

Question-- it looks like props currently being passed into TopBar from FullScreen are not actually used by TopBar:
title={title} index={index} params={params} subtitle={structure.name} 

So I deleted these-- just confirming this is fine? 
