### PR TITLE
Support Utility Tiny Caps style

### DIFF
--- a/client/component/text.js
+++ b/client/component/text.js
@@ -140,7 +140,7 @@ export function UtilityText({type='small', center=false, right=false, text, labe
     const styleMap = {
         large: s.utilityLarge,
         small: s.utilitySmall,
-        tiny: s.utilityTiny,
+        tiny: caps ? s.utilityTinyCaps : s.utilityTiny,
     }
     const strongMap = {
         large: fontFamilySansMedium,
@@ -174,6 +174,11 @@ const UtilityTextStyle = StyleSheet.create({
     },
     utilityTiny: {
         fontFamily: fontFamilySansMedium,
+        fontSize: 12,
+        lineHeight: 12 * 1.25,
+    },
+    utilityTinyCaps: {
+        fontFamily: fontFamilySansRegular,
         fontSize: 12,
         lineHeight: 12 * 1.25,
     }


### PR DESCRIPTION
From Tori:
Please use “Utility tiny caps” ([a new style in the design system](https://www.figma.com/design/MX0AcO8d0ZlCBs4e9vkl5f/PSI-Design-System?node-id=1102-3167&t=34xR4SHdHVx8vPIa-1)) – it’s Regular weight instead of Medium