### PR TITLE
Profile set up screen VQA

### DIFF
--- a/client/component/people.js
+++ b/client/component/people.js
@@ -47,7 +47,7 @@ export function MyProfilePhoto({type='large', photo=null, faint=false, check=fal
 export function FaceImage({face, photoUrl=null, type='small', faint=false, check=false, border=false}) {
     const sizeMap = {
         huge: 80,
-        large: 40,
+        large: 48,
         small: 32,
         tiny: 24,
     }
@@ -85,7 +85,7 @@ export function LetterFace({name, hue, type='large'}) {
     const s = LetterFaceStyle;
     const sizeMap = {
         huge: 80,
-        large: 40,
+        large: 48,
         small: 32,
         tiny: 24,
     }

--- a/client/component/people.js
+++ b/client/component/people.js
@@ -47,7 +47,8 @@ export function MyProfilePhoto({type='large', photo=null, faint=false, check=fal
 export function FaceImage({face, photoUrl=null, type='small', faint=false, check=false, border=false}) {
     const sizeMap = {
         huge: 80,
-        large: 48,
+        extraLarge: 48,
+        large: 40,
         small: 32,
         tiny: 24,
     }
@@ -85,7 +86,8 @@ export function LetterFace({name, hue, type='large'}) {
     const s = LetterFaceStyle;
     const sizeMap = {
         huge: 80,
-        large: 48,
+        extraLarge: 48,
+        large: 40,
         small: 32,
         tiny: 24,
     }

--- a/client/component/text.js
+++ b/client/component/text.js
@@ -18,6 +18,7 @@ export function Heading({text, color={color}, center, label, level=2, underline=
     const styleMap = {
         1: HeadingStyle.heading1,
         2: HeadingStyle.heading2,
+        3: HeadingStyle.heading3,
     }
     return <TranslatableText text={text} label={label} formatParams={formatParams} 
         style={[

--- a/client/component/text.js
+++ b/client/component/text.js
@@ -38,6 +38,11 @@ const HeadingStyle = StyleSheet.create({
         fontSize: 16,
         lineHeight: 16 * 1.25
     },
+    heading3: {
+        fontFamily: fontFamilySansMedium,
+        fontSize: 14,
+        lineHeight: 14 * 1.25
+    }
 })
 
 export function DataVizText({type, text, label, formatParams}) {

--- a/client/demo/profileedit-demo.js
+++ b/client/demo/profileedit-demo.js
@@ -94,18 +94,18 @@ function profileStorySets() {return [
         }},
         stories: [
             {label: 'Just Continue', actions: [
-                CLICK('Continue')
+                CLICK('Finish')
             ]},
             {label: 'Letter Photo', actions: [
-                CLICK('letter'), CLICK('Continue')
+                CLICK('letter'), CLICK('Finish')
             ]},
             {label: 'Good Pseudonym', actions: [
                 CLICK('A pseudonym'), 
-                INPUT('pseudonym', 'malice'), CLICK('Continue')
+                INPUT('pseudonym', 'malice'), CLICK('Finish')
             ]},
             {label: 'Bad Pseudonym', actions: [
                 CLICK('A pseudonym'), 
-                INPUT('pseudonym', 'meanword'), CLICK('Continue')
+                INPUT('pseudonym', 'meanword'), CLICK('Finish')
             ]},
 
         ]

--- a/client/feature/ProfilePhotoAndName.js
+++ b/client/feature/ProfilePhotoAndName.js
@@ -108,11 +108,11 @@ function ProfilePhotoEditor() {
 
     return <HorizBox>
         <FaceSelect testID='photo' selected={isPhoto} onSelect={onSelectPhoto}>
-            <FaceImage type='large' photoUrl={photoUrl ?? fbUser.photoURL} />
+            <FaceImage type='extraLarge' photoUrl={photoUrl ?? fbUser.photoURL} />
         </FaceSelect>
         <Pad size={16} />
         <FaceSelect testID='letter' selected={!isPhoto} onSelect={onSelectLetter}>
-            <LetterFace type='large' hue={defaultHue} name={name} />
+            <LetterFace type='extraLarge' hue={defaultHue} name={name} />
         </FaceSelect>
     </HorizBox>
 }

--- a/client/feature/ProfilePhotoAndName.js
+++ b/client/feature/ProfilePhotoAndName.js
@@ -1,4 +1,4 @@
-import { HorizBox, Pad } from "../component/basics";
+import { HorizBox, Pad, PadBox } from "../component/basics";
 import { Heading, Paragraph, TextField, UtilityText } from "../component/text";
 import { StyleSheet, View } from "react-native";
 import { useDatastore, useInstanceKey, usePersonaKey, usePersonaObject } from "../util/datastore";
@@ -65,16 +65,16 @@ function EditPhotoAndName() {
     }
 
     return <View>
-        <Heading label='Profile name'/>
-        <Pad size={12} />
+        <Heading level={3} label='Profile name'/>
+        <Pad size={8} />
         <RadioGroup value={nameMode} onChange={onChangeNameMode}>
             <RadioOption radioKey='full' text={fbUser.displayName} />
             <RadioOption radioKey='custom' label='A pseudonym' />
         </RadioGroup>
         {nameMode == 'custom' && <Catcher><PseudonymEditor /></Catcher>}
-        <Pad size={24}/>
-        <Heading label='Your profile photo'/>
-        <Pad size={20} />
+        <Pad size={32}/>
+        <Heading level={3} label='Your profile photo'/>
+        <Pad size={12} />
         <Catcher><ProfilePhotoEditor /></Catcher>
     </View>
 }
@@ -108,11 +108,11 @@ function ProfilePhotoEditor() {
 
     return <HorizBox>
         <FaceSelect testID='photo' selected={isPhoto} onSelect={onSelectPhoto}>
-            <FaceImage type='huge' photoUrl={photoUrl ?? fbUser.photoURL} />
+            <FaceImage type='large' photoUrl={photoUrl ?? fbUser.photoURL} />
         </FaceSelect>
-        <Pad size={24} />
+        <Pad size={16} />
         <FaceSelect testID='letter' selected={!isPhoto} onSelect={onSelectLetter}>
-            <LetterFace type='huge' hue={defaultHue} name={name} />
+            <LetterFace type='large' hue={defaultHue} name={name} />
         </FaceSelect>
     </HorizBox>
 }
@@ -174,7 +174,6 @@ function previewPhotoAndName({updates}) {
 }
 
 export function FirstLoginSetup({onFieldsChosen}) {
-    const s = FirstLoginSetupStyle;
     const datastore = useDatastore();
     const fbUser = datastore.getFirebaseUser();
 
@@ -183,7 +182,7 @@ export function FirstLoginSetup({onFieldsChosen}) {
     const [errors, setErrors] = useState({});
     const [inProgress, setInProgress] = useState(false);
  
-    async function onContinue() {
+    async function onFinish() {
         setInProgress(true);
         const errors = await checkPhotoAndNameAsync({datastore, updates});
         if (errors) {
@@ -199,25 +198,20 @@ export function FirstLoginSetup({onFieldsChosen}) {
         onFieldsChosen({updates, preview});
     }
 
-    return <View style={s.outer}>
-        <Heading level={1} label="Let's get your profile set up" />
-        <Pad size={8} />
-        <Paragraph label='How do you want to appear to others?' />
-        <Pad size={40} />
-        <WithEditableFields updates={updates} setUpdates={setUpdates} errors={errors}>
-            <EditPhotoAndName />
-        </WithEditableFields>
-        <Pad size={32} />
-        <CTAButton wide disabled={inProgress} label={inProgress ? 'Please Wait...' : 'Continue'} onPress={onContinue} />
+    return <View>
+        <PadBox horiz={20} vert={20}>
+            <Heading level={1} label="Let's get your profile set up" />
+            <Pad size={8} />
+            <Paragraph type='large' label='How do you want to appear to others in your posts and replies?' />
+            <Pad size={40} />
+            <WithEditableFields updates={updates} setUpdates={setUpdates} errors={errors}>
+                <EditPhotoAndName />
+            </WithEditableFields>
+            <Pad size={32} />
+            <CTAButton disabled={inProgress} label={inProgress ? 'Please Wait...' : 'Finish'} onPress={onFinish} />
+        </PadBox>
     </View>
 }
-const FirstLoginSetupStyle = StyleSheet.create({
-    outer: {
-        backgroundColor: colorPinkBackground,
-        padding: 20,
-        borderRadius: 12
-    }
-});
 
 export function FirstLoginSetupTester() {
     const [updates, setUpdates] = useState(null);

--- a/client/translations/ui_french.js
+++ b/client/translations/ui_french.js
@@ -72,12 +72,13 @@ export var ui_translations_french = {
     'Pseudonyms can contain only lower case letters and numbers.': 'Les pseudonymes ne peuvent contenir que des lettres minuscules et des chiffres.',
     'You can change your pseudonym at most once a week': 'Vous ne pouvez changer votre pseudonyme qu\'une fois par semaine au maximum',
     "Let's get your profile set up": 'Créons votre profil',
-    'How do you want to appear to others?': 'Comment souhaitez-vous apparaître aux autres ?',
+    'How do you want to appear to others in your posts and replies?': 'Comment souhaitez-vous apparaître aux autres dans vos publications et réponses?',
     'Save': 'Enregistrer',
     'Edit {tLabel}': 'Modifier {tLabel}',
     'photo and name': 'photo et nom',
     'Please Wait...': 'Veuillez patienter...',
     'Continue': 'Continuer',
     'Saving...' : 'Enregistrement en cours...',
+    'Finish' : 'Terminer',
 
 }

--- a/client/translations/ui_german.js
+++ b/client/translations/ui_german.js
@@ -70,11 +70,12 @@ export var ui_translations_german = {
     'Pseudonyms can contain only lower case letters and numbers.': 'Pseudonyme können nur Kleinbuchstaben und Zahlen enthalten.',
     'You can change your pseudonym at most once a week': 'Du kannst dein Pseudonym höchstens einmal pro Woche ändern',
     "Let's get your profile set up": 'Lass uns dein Profil einrichten',
-    'How do you want to appear to others?': 'Wie möchtest du anderen erscheinen?',
+    'How do you want to appear to others in your posts and replies?': 'Wie möchten Sie in Ihren Beiträgen und Antworten auf andere wirken?',
     'Save': 'Speichern',
     'Edit {tLabel}': '{tLabel} bearbeiten',
     'photo and name': 'Foto und Name',
     'Please Wait...': 'Bitte warten...',
     'Continue': 'Fortsetzen',
+    'Finish' : 'Fertig', 
 
 }


### PR DESCRIPTION
From Tori:
- Make it white instead of yellow with no background color and the same margin around it as a normal page (like the current Log in screen)

Subheadline
- The subhealdine should say “How do you want to appear to others in your posts and replies?” (Right now, it says “How do you want to appear to others?”)
- The text should be “Paragraph large” (so it should be 16px instead of 14px)

“Profile name” and “Profile photo”
- Both should be “Utility small medium” (so they should be 14px Medium instead of 16px Semibold)
Spacing
- This spacer under “Profile name” should be 8px instead of 12px
- This spacer under the profile name section should be 32px instead of 24px
- This spacer under “Your profile photo” should be 12px instead of 20px

Profile photo
- The profile photo should be 48px instead of 80px (we talked about adding this size as “Large” to the design system [here](https://www.figma.com/design/MX0AcO8d0ZlCBs4e9vkl5f/PSI-Design-System?node-id=1102-4732&t=L7WsbJRwzpRdqvhc-1))
- Horizontal distance between the two photo options should be 16px instead of 24px