### PR TITLE
Support turning off multiline textfields and compact Tags

### DIFF
--- a/client/component/button.js
+++ b/client/component/button.js
@@ -242,13 +242,14 @@ const ExpanderButtonStyle = StyleSheet.create({
     }
 })
 
-export function Tag({label, emoji, text, type='emphasized', strong=false, formatParams, color=null, onPress}) {
+export function Tag({label, emoji, text, type='emphasized', strong=false, formatParams, color=null, onPress, compact=false}) {
     const s = TagStyle;
     return <View style={[
                 s.button, 
                 type == 'emphasized' && s.emphasized, 
                 type == 'tiny' && s.tiny,      
-                color && {borderColor: color, backgroundColor: color}
+                color && {borderColor: color, backgroundColor: color},
+                compact && {height: 28}
             ]} 
             hoverStyle={s.hover} onPress={onPress}>
         {emoji && <PadBox right={6}><UtilityText text={emoji} type='tiny' strong /></PadBox>}
@@ -352,7 +353,6 @@ const FilterButtonStyle = StyleSheet.create({
     pressed: {
         borderColor: colorTextBlue,        
         backgroundColor: colorWhite,
-        borderColor: colorTextBlue,
     }
 });
 

--- a/client/component/text.js
+++ b/client/component/text.js
@@ -215,7 +215,7 @@ export function LinkText({type='small', text, url, label, formatParams}) {
 // node, but that doesn't seem to work in current versions of react-native-web
 export var global_textinput_test_handlers = {};
 
-export function AutoSizeTextInput({value, onChange, placeholder, style, hoverStyle=null, maxHeight = 400, emptyHeight = 54, testID, ...props}) {
+export function AutoSizeTextInput({value, onChange, placeholder, style, hoverStyle=null, maxHeight = 400, emptyHeight = 54, testID, multiline = true, ...props}) {
     const [height, setHeight] = useState(0);
     const [hover, setHover] = useState(false);
 
@@ -250,21 +250,22 @@ export function AutoSizeTextInput({value, onChange, placeholder, style, hoverSty
             placeholder={placeholder} 
             placeholderTextColor={colorDisabledText}
             onMouseEnter={() => setHover(true)} onMouseLeave={() => setHover(false)}
-            multiline={true} 
+            multiline={multiline} 
             testID={testID}
             style={[style, {height: styleHeight}, hover ? hoverStyle : null]} 
             onContentSizeChange={onContentSizeChange} {...props} />
     </View>
 }
 
-export function TextField({value, error=false, big=false, autoFocus=false, placeholder, testID, placeholderParams, onChange, onFocusChange}) {
+export function TextField({value, error=false, big=false, autoFocus=false, placeholder, testID, placeholderParams, onChange, onFocusChange, multiline}) {
     const s = TextFieldStyle;
     const tPlaceholder = useTranslation(placeholder, placeholderParams);
     return <AutoSizeTextInput value={value ?? ''} onChange={onChange} 
         emptyHeight={big ? 300 : 54} autoFocus={autoFocus} testID={testID}
         style={[s.textField, error ? {borderColor: colorRed} : null]} hoverStyle={s.hover}
         placeholder={tPlaceholder} placeholderTextColor={colorDisabledText} 
-        onFocus={() => onFocusChange?.(true)} onBlur={() => onFocusChange?.(false)}/>
+        onFocus={() => onFocusChange?.(true)} onBlur={() => onFocusChange?.(false)}
+        multiline={multiline}/>
 }
 
 const TextFieldStyle = StyleSheet.create({


### PR DESCRIPTION
Turning off multiline gets rid of the scroll bar on single line text fields
Compact tag is needed for Representing perspectives