### PR TITLE
Create Clickable Tag component for Representing Perspectives

### DIFF
--- a/client/component/button.js
+++ b/client/component/button.js
@@ -8,7 +8,7 @@ import { PopupBase } from "../platform-specific/popup";
 import { Information, Close, ChevronDown, ChevronUp } from '@carbon/icons-react';
 
 
-export function CTAButton({label, text, formatParams, icon, type='primary', disabled, compact=false, wide=false, onPress}) {
+export function CTAButton({label, text, formatParams, icon, type='primary', disabled, size='large', wide=false, borderless=false, onPress}) {
     const s = CTAButtonStyle;
 
     const styleMap = {
@@ -19,12 +19,18 @@ export function CTAButton({label, text, formatParams, icon, type='primary', disa
         delete: {normal: s.delete, hover: s.deleteHover, pressed: s.deletePressed, textColor: colorRed}
     }
     const {normal, hover, pressed, textColor} = styleMap[disabled ? 'disabled' : type] ?? styleMap.primary;
+
+    const sizeMap = {
+        large: s.largeButton,
+        compact: s.compactButton,
+        small: s.smallButton,
+    };    
         
     return <HoverView disabled={disabled} role='button' testID={label ?? text}
-            style={[compact ? s.compactButton : s.button, wide && s.wide, normal]} hoverStyle={[s.hover, hover]} 
+            style={[sizeMap[size], wide && s.wide, normal, borderless && s.borderless]} hoverStyle={[s.hover, hover]} 
             pressedStyle={pressed} onPress={onPress} >
-        {icon && <PadBox right={8}>{icon}</PadBox>}
-        <UtilityText type='large' label={label} text={text} formatParams={formatParams} color={textColor} />
+        {icon && <PadBox right={size === 'small' ? 6 : 8}>{icon}</PadBox>}
+        <UtilityText type={size === 'small' ? 'tiny' : 'large'} label={label} text={text} formatParams={formatParams} color={textColor} />
     </HoverView>
 }
 
@@ -81,7 +87,7 @@ const CTAButtonStyle = StyleSheet.create({
         borderColor: colorDisabledBackground,
         color: colorDisabledText
     },
-    button: {
+    largeButton: {
         paddingHorizontal: 16,
         paddingVertical: 12,
         borderRadius: 32,
@@ -100,13 +106,29 @@ const CTAButtonStyle = StyleSheet.create({
         alignItems: 'center',
         borderWidth: 1   
     },
+    smallButton: {
+        paddingHorizontal: 12,
+        height: 28,
+        borderRadius: 32,
+        alignSelf: 'flex-start',
+        flexDirection: 'row',
+        alignItems: 'center',
+        borderWidth: 1   
+    },
     wide: {
         alignSelf: 'stretch',    
         justifyContent: 'center',
         flex: 1
+    },
+    borderless: {
+        borderWidth: 0
     }
 })
 
+export function ClickableTag({label, emoji, onPress}) {
+    return <CTAButton label={label} icon={emoji && <UtilityText text={emoji} type="tiny" />}
+    type="secondary" size="small" borderless onPress={onPress} />
+}
 
 export function IconButton({label, icon=null, iconProps={}, wide=false, onPress}) {
     const s = IconReplyStyle;
@@ -242,14 +264,15 @@ const ExpanderButtonStyle = StyleSheet.create({
     }
 })
 
-export function Tag({label, emoji, text, type='emphasized', strong=false, formatParams, color=null, onPress, compact=false}) {
+export function Tag({label, emoji, text, type='emphasized', strong=false, formatParams, color=null, onPress, compact=false, dashed=false, borderColor=null}) {
     const s = TagStyle;
     return <View style={[
                 s.button, 
                 type == 'emphasized' && s.emphasized, 
                 type == 'tiny' && s.tiny,      
-                color && {borderColor: color, backgroundColor: color},
-                compact && {height: 28}
+                color && {borderColor: borderColor || color, backgroundColor: color},
+                compact && {height: 28},
+                dashed && {borderStyle: 'dashed'}
             ]} 
             hoverStyle={s.hover} onPress={onPress}>
         {emoji && <PadBox right={6}><UtilityText text={emoji} type='tiny' strong /></PadBox>}

--- a/client/component/topbar.js
+++ b/client/component/topbar.js
@@ -37,7 +37,7 @@ export function TopBar() {
         <Catcher>
             <HorizBox center>
                 {toolbarAction ? 
-                    <PadBox right={12}><CTAButton compact label={toolbarAction.label} disabled={toolbarAction.disabled} onPress={toolbarAction.onPress} /></PadBox>
+                    <PadBox right={12}><CTAButton size='compact' label={toolbarAction.label} disabled={toolbarAction.disabled} onPress={toolbarAction.onPress} /></PadBox>
                 : 
                     instanceKey && !isLogin && <UserInfo />
                 }
@@ -244,7 +244,7 @@ function UserInfo() {
         </Popup>
     } else {        
         return <PadBox horiz={20}>
-            <CTAButton type='secondary' onPress={onLogin} compact label='Log in' />
+            <CTAButton type='secondary' onPress={onLogin} size='compact' label='Log in' />
         </PadBox>
     }
 }

--- a/client/demo/designsystem-demo.js
+++ b/client/demo/designsystem-demo.js
@@ -3,7 +3,7 @@ import { Datastore, usePersonaKey } from "../util/datastore";
 import { IconUpvote, IconUpvoted } from "../component/icon";
 import { CharacterCounter, CircleCount, DataVizText, EditorialHeading, Heading, Paragraph, TextField, TextFieldButton, UtilityText } from "../component/text";
 import { colorBlack, colorLightGreen, colorPink, colorRed, colorTextBlue, colorTextGrey } from "../component/color";
-import { BannerIconButton, BreadCrumb, CTAButton, DropDownSelector, ExpandButton, FilterButton, IconButton, PhotoPile, PopupPanel, ReactionButton, SubtleButton, Tag, TextButton } from "../component/button";
+import { BannerIconButton, BreadCrumb, CTAButton, DropDownSelector, ExpandButton, FilterButton, IconButton, PhotoPile, PopupPanel, ReactionButton, SubtleButton, Tag, ClickableTag, TextButton } from "../component/button";
 import { Checkbox, Toggle, RadioOption, RadioGroup, FormField, AccordionField } from "../component/form";
 import { useState } from "react";
 import { RichText } from "../component/richtext";
@@ -306,7 +306,7 @@ function ButtonsAndLinksScreen() {
                     <CTAButton label='Disabled' type='primary' disabled />
                 </SpacedArray>
                 <CTAButton wide label='Wide' onPress={onPress} />
-                <CTAButton compact label='Compact' onPress={onPress} />
+                <CTAButton size='compact' label='Compact' onPress={onPress} />
             </DemoSection>
             <DemoSection label='Action Button'>
                 <SpacedArray horiz>
@@ -404,6 +404,10 @@ function TagsScreen() {
             <Tag label='Subtle Tag' type='subtle' />
             <Tag emoji='🔥' label='Emphasized Tag' type='emphasized' color={colorPink} />
             <Tag label='Tiny Tag' type='tiny' />
+        </DemoSection>
+        <DemoSection label='Clickable Tag' color={colorPink}>
+            <ClickableTag label='Standard' onPress={() => {}} />
+            <ClickableTag label='Standard With Emoji' emoji='🔥' onPress={() => {}} />
         </DemoSection>
     </View>
 }

--- a/client/feature/AdminUsersFeature.js
+++ b/client/feature/AdminUsersFeature.js
@@ -99,7 +99,7 @@ function AddAdminUsers({onUsersAdded}) {
         {toBool(emails) &&  <HorizBox>
             <RoleSelectorPopup selectedRoles={selectedRoles} setSelectedRoles={setSelectedRoles} />
             <Pad />
-            <CTAButton compact disabled={inProgress || selectedRoles.length == 0} label='Add Admins' onPress={onAdd} />
+            <CTAButton size='compact' disabled={inProgress || selectedRoles.length == 0} label='Add Admins' onPress={onAdd} />
         </HorizBox>}
         {toBool(inProgress) && <UtilityText label='Adding Admins...' />}
     </FormField>

--- a/client/structure/profile.js
+++ b/client/structure/profile.js
@@ -115,7 +115,7 @@ export function ProfileModuleHolder({module}) {
                 {React.createElement(module.view)}
                 <Pad size={24} />
                 {isMyProfile && module.edit && <CTAButton
-                    type='secondary' compact 
+                    type='secondary' size='compact' 
                     label='Edit {tLabel}' formatParams={{tLabel}} 
                     onPress={() => setEditing(true)} />
                 }

--- a/client/system/demo.js
+++ b/client/system/demo.js
@@ -31,12 +31,12 @@ export function POPUP_CLOSE() {
 }
 
 
-export function DemoSection({label, horiz=false, children}) {
+export function DemoSection({label, horiz=false, children, color=null}) {
     const s = DemoSectionStyle;
     return <View style={{marginBottom: 32}}>
         <Heading type='small' label={label} />
         <Pad size={8} />
-        <View style={s.box}>
+        <View style={[s.box, color && {backgroundColor: color}]}>
             <Catcher>
                 <SpacedArray horiz={horiz}>{children}</SpacedArray>
             </Catcher>


### PR DESCRIPTION
Creates a Clickable Tag component as described in the design system:
https://www.figma.com/design/MX0AcO8d0ZlCBs4e9vkl5f/PSI-Design-System?node-id=1418-6360&t=eT7j9C3b6UzR5aQg-1

Also updates Tag to support dashed border (also needed for Rep Perspectives)

I based Clickable Tag off CTA button, but had to add a third size option to CTA. This meant updating all the uses of the CTA 'compact' prop throughout the codebase to use size instead. The only use of compact in psi-product is in Rep. Perspectives (which is updated in https://github.com/wearenewpublic/psi-product/pull/181). The remaining examples are all np-platform and are all fixed in this PR.