### PR TITLE
Update text styles in design system

### DIFF
--- a/client/component/banner.js
+++ b/client/component/banner.js
@@ -46,7 +46,7 @@ const BannerStyle = StyleSheet.create({
 
 export function BannerMessage({label, text, formatParams, error=false}) {
     return <Banner color={error ? colorRedBackground : colorLightBlueBackground}>
-        <UtilityText strong label={label} text={text} formatParams={formatParams} />
+        <UtilityText weight='medium' label={label} text={text} formatParams={formatParams} />
     </Banner>
 }
 

--- a/client/component/button.js
+++ b/client/component/button.js
@@ -354,7 +354,8 @@ export function FilterButton({emoji, label, text, count, selected, onPress}) {
     return <HoverView style={[s.button, selected && s.pressed]} pressedStyle={s.pressed} hoverStyle={s.hover} 
             onPress={onPress} setPressed={setPressed} testID={label ?? text}>
         {emoji && <PadBox right={8}><UtilityText text={emoji} type='tiny' weight='strong' /></PadBox>}
-        <UtilityText label={label} text={text} type='tiny' weight='medium'/>
+        <UtilityText label={label} text={text} type='tiny' weight='medium'
+            color={(pressed || selected) ? colorTextBlue : colorBlack} />
         {count ? <Pad size={8} /> : null}
         <UtilityText text={count} type='tiny' weight='medium' color={colorRed} />
     </HoverView>

--- a/client/component/button.js
+++ b/client/component/button.js
@@ -126,7 +126,7 @@ const CTAButtonStyle = StyleSheet.create({
 })
 
 export function ClickableTag({label, emoji, onPress}) {
-    return <CTAButton label={label} icon={emoji && <UtilityText text={emoji} type="tiny" />}
+    return <CTAButton label={label} icon={emoji && <UtilityText text={emoji} type="tiny" weight='medium' />}
     type="secondary" size="small" borderless onPress={onPress} />
 }
 
@@ -275,10 +275,10 @@ export function Tag({label, emoji, text, type='emphasized', strong=false, format
                 dashed && {borderStyle: 'dashed'}
             ]} 
             hoverStyle={s.hover} onPress={onPress}>
-        {emoji && <PadBox right={6}><UtilityText text={emoji} type='tiny' strong /></PadBox>}
+        {emoji && <PadBox right={6}><UtilityText text={emoji} type='tiny' weight='strong' /></PadBox>}
         <UtilityText color={type=='tiny' ? colorTextBlue : null} 
             label={label} text={text} formatParams={formatParams} 
-            strong={strong} type='tiny' />
+            strong={strong} type='tiny' weight='medium' />
     </View>
 }
 const TagStyle = StyleSheet.create({
@@ -313,11 +313,10 @@ export function ReactionButton({emoji, viewOnly=false, label, text, count, selec
     return <HoverView style={[s.horiz, !viewOnly && s.button, selected && s.pressed]} 
             hoverStyle={s.hover} disabled={viewOnly} testID={label ?? text}
             pressedStyle={s.pressed} setPressed={setPressed} role='button' onPress={onPress}>
-        {emoji && <PadBox right={8}><UtilityText text={emoji} type='tiny' strong /></PadBox>}
-        <UtilityText label={label} text={text} type='tiny' 
-            color={(pressed || selected) ? colorTextBlue : colorBlack} />
+        {emoji && <PadBox right={8}><UtilityText text={emoji} type='tiny' weight='strong' /></PadBox>}
+        <UtilityText label={label} text={text} type='tiny' weight='medium' />
         {count ? <Pad size={8} /> : null}
-        <UtilityText text={count} type='tiny' color={colorRed} />
+        <UtilityText text={count} type='tiny' weight='medium' color={colorRed} />
     </HoverView>
 }
 const ReactionButtonStyle = StyleSheet.create({
@@ -353,11 +352,10 @@ export function FilterButton({emoji, label, text, count, selected, onPress}) {
 
     return <HoverView style={[s.button, selected && s.pressed]} pressedStyle={s.pressed} hoverStyle={s.hover} 
             onPress={onPress} setPressed={setPressed} testID={label ?? text}>
-        {emoji && <PadBox right={8}><UtilityText text={emoji} type='tiny' strong /></PadBox>}
-        <UtilityText label={label} text={text} type='tiny' 
-            color={(pressed || selected) ? colorTextBlue : colorBlack} />
+        {emoji && <PadBox right={8}><UtilityText text={emoji} type='tiny' weight='strong' /></PadBox>}
+        <UtilityText label={label} text={text} type='tiny' weight='medium'/>
         {count ? <Pad size={8} /> : null}
-        <UtilityText text={count} type='tiny' color={colorRed} />
+        <UtilityText text={count} type='tiny' weight='medium' color={colorRed} />
     </HoverView>
 }
 const FilterButtonStyle = StyleSheet.create({
@@ -393,9 +391,9 @@ export function DropDownSelector({label, options, value, onChange=()=>{}}) {
     }
     return <PopupPanel popupContent={popupContent} alignRight setHover={setHover}>
         <HorizBox>
-            <UtilityText label={label} type='tiny' strong />
-            <UtilityText text=': ' type='tiny' strong />
-            <UtilityText label={selectedOption.label} type='tiny' underline={hover} strong />
+            <UtilityText label={label} type='tiny' weight='strong' />
+            <UtilityText text=': ' type='tiny' weight='strong' />
+            <UtilityText label={selectedOption.label} type='tiny' underline={hover} weight='strong' />
         </HorizBox>
     </PopupPanel>
 }

--- a/client/component/button.js
+++ b/client/component/button.js
@@ -314,7 +314,8 @@ export function ReactionButton({emoji, viewOnly=false, label, text, count, selec
             hoverStyle={s.hover} disabled={viewOnly} testID={label ?? text}
             pressedStyle={s.pressed} setPressed={setPressed} role='button' onPress={onPress}>
         {emoji && <PadBox right={8}><UtilityText text={emoji} type='tiny' weight='strong' /></PadBox>}
-        <UtilityText label={label} text={text} type='tiny' weight='medium' />
+        <UtilityText label={label} text={text} type='tiny' weight='medium'
+            color={(pressed || selected) ? colorTextBlue : colorBlack} />
         {count ? <Pad size={8} /> : null}
         <UtilityText text={count} type='tiny' weight='medium' color={colorRed} />
     </HoverView>

--- a/client/component/button.js
+++ b/client/component/button.js
@@ -170,7 +170,7 @@ export function SubtleButton({label, text, ariaLabel, testID, disabled, formatPa
             onPress={onPress} setHover={setHover}>
         {React.createElement(icon, {...iconProps, color})}
         {(label || text) && <Pad size={4} />}
-        <UtilityText label={label} text={text} strong={strong} underline={hover} 
+        <UtilityText label={label} text={text} weight={strong ? 'medium' : 'regular'} underline={hover} 
             color={color} formatParams={formatParams} type='tiny' />
     </HoverView>
 }

--- a/client/component/form.js
+++ b/client/component/form.js
@@ -11,7 +11,7 @@ import { ChevronDown, ChevronUp, RadioButton, RadioButtonChecked, CheckboxChecke
 export function FormField({label, descriptionLabel, errorLabel, required, children}) {
     return <View>
         <HorizBox>
-            <UtilityText type='small' strong label={label} />
+            <UtilityText type='small' weight="medium" label={label} />
             {required && <UtilityText type='small' label='*' color={colorRed} />}
         </HorizBox>
         <Pad size={8} />
@@ -50,7 +50,7 @@ export function RadioOption({emoji, text, radioKey, label}) {
             <HorizBox center>
                 {value ? <RadioButtonChecked size={32} /> : <RadioButton size={32} style={{fill: colorGreyBorder}} />}
                 <Pad size={12} />
-                {emoji && <PadBox right={6}><UtilityText text={emoji} type='tiny' strong /></PadBox>}
+                {emoji && <PadBox right={6}><UtilityText text={emoji} type='tiny' weight='strong' /></PadBox>}
                 <UtilityText text={text} label={label} />
             </HorizBox>
         </PadBox>
@@ -76,7 +76,7 @@ export function Checkbox({emoji, text, label, value, onChange, size=32}) {
                     {value ? <CheckboxCheckedFilled size={size} /> : <CheckboxOpen size={size} style={{fill: colorGreyBorder}} />}
                 </View>
                 <Pad size={12} />
-                {emoji && <PadBox right={6}><UtilityText text={emoji} type='tiny' strong /></PadBox>}
+                {emoji && <PadBox right={6}><UtilityText text={emoji} type='tiny' weight='strong' /></PadBox>}
                 <UtilityText text={text} label={label} />
             </HorizBox>
         </PadBox>
@@ -130,7 +130,7 @@ export function Toggle({emoji, text, label, value, spread, onChange}) {
         <PadBox vert={8}>
             <HorizBox center spread={spread}>        
                     <HorizBox center shrink>
-                        {emoji && <PadBox right={8}><UtilityText text={emoji} type='tiny' strong /></PadBox>}
+                        {emoji && <PadBox right={8}><UtilityText text={emoji} type='tiny' weight='strong' /></PadBox>}
                         <UtilityText text={text} label={label} />
                     </HorizBox>
                     <Pad size={12} />

--- a/client/component/help.js
+++ b/client/component/help.js
@@ -39,7 +39,7 @@ export function HelpBubble({label, text, titleLabel, titleText, padTop=4, above=
                 ]}>
                 <HorizBox spread>
                     <View style={{flex: 1}}>
-                        {hasTitle && <UtilityText type='small' strong 
+                        {hasTitle && <UtilityText type='small' weight="medium" 
                             label={titleLabel} text={titleText} 
                             color={colorGreyPopupBackground} 
                         />}

--- a/client/component/people.js
+++ b/client/component/people.js
@@ -176,7 +176,7 @@ export function Byline({ type = 'small', photoType = null, clickable = true, use
                 {clickable ?
                     <TextButton type='small' strong text={name ?? persona?.name} underline={underline} onPress={onProfile} />
                 :
-                    <UtilityText strong text={name ?? persona?.name} underline={underline} />
+                    <UtilityText weight='medium' text={name ?? persona?.name} underline={underline} />
                 }
                 <Pad size={oneLine ? 8 : 4} />
                 {time && <UtilityText color={colorTextGrey}

--- a/client/component/text.js
+++ b/client/component/text.js
@@ -165,17 +165,17 @@ const ParagraphStyle = StyleSheet.create({
 
 
 
-export function UtilityText({type='small', center=false, right=false, text, label, formatParams, color='black', strong=false, caps=false, underline=false, numberOfLines=null, ellipsizeMode='tail'}) {
+export function UtilityText({type='small', center=false, right=false, text, label, formatParams, color='black', weight='regular', caps=false, underline=false, numberOfLines=null, ellipsizeMode='tail'}) {
     const s = UtilityTextStyle;
     const styleMap = {
         large: s.utilityLarge,
         small: s.utilitySmall,
         tiny: caps ? s.utilityTinyCaps : s.utilityTiny,
     }
-    const strongMap = {
-        large: fontFamilySansMedium,
-        small: fontFamilySansMedium,
-        tiny: fontFamilySansSemiBold,
+    const weightMap = {
+        regular: fontFamilySansRegular,
+        medium: fontFamilySansMedium,
+        strong: fontFamilySansSemiBold,
     }
     if (!text && !label) return null;
     return <TranslatableText text={text} label={label} role="paragraph" formatParams={formatParams}
@@ -183,36 +183,26 @@ export function UtilityText({type='small', center=false, right=false, text, labe
         style={[
             styleMap[type], {color}, 
             underline && {textDecorationLine: 'underline'},
-            strong && {fontFamily: strongMap[type]},
+            weight && {fontFamily: weightMap[weight]},
             center && {textAlign: 'center'},
             right && {textAlign: 'right'},
             caps && {textTransform: 'uppercase', letterSpacing: 0.5}
         ]} />
 }
 
-
-
 const UtilityTextStyle = StyleSheet.create({
     utilityLarge: {
-        fontFamily: fontFamilySansRegular,
         fontSize: 16,
         lineHeight: 16 * 1.25
     },
     utilitySmall: {
-        fontFamily: fontFamilySansRegular,
         fontSize: 14, 
         lineHeight: 14 * 1.25
     },
     utilityTiny: {
-        fontFamily: fontFamilySansMedium,
         fontSize: 12,
         lineHeight: 12 * 1.25,
     },
-    utilityTinyCaps: {
-        fontFamily: fontFamilySansRegular,
-        fontSize: 12,
-        lineHeight: 12 * 1.25,
-    }
 })
 
 export function WebLink({url, style, setHover, children}) {
@@ -364,19 +354,19 @@ export function CharacterCounter({max, min, text}) {
     const count = text?.length ?? 0;
 
     if (count == 0) {
-        return <UtilityText type='tiny' label='{min} characters min' formatParams={{min}} 
+        return <UtilityText type='tiny' weight='medium' label='{min} characters min' formatParams={{min}} 
             color={colorDisabledText} />
     } else if (count < min) {
-        return <UtilityText type='tiny' label='{count}/{min} characters min' formatParams={{count,min}} 
+        return <UtilityText type='tiny' weight='medium' label='{count}/{min} characters min' formatParams={{count,min}} 
             color={colorDisabledText} />
     } else if (count > max) {
-        return <UtilityText type='tiny' label='{count}/{max} characters max' formatParams={{count,max}} 
+        return <UtilityText type='tiny' weight='medium' label='{count}/{max} characters max' formatParams={{count,max}} 
             color={colorRed} />
     } else {
         return <HorizBox>
             <Checkmark />
             <Pad size={8} />
-            <UtilityText type='tiny' label='{count}/{max} characters max' formatParams={{count,max}} />
+            <UtilityText type='tiny' weight='medium' label='{count}/{max} characters max' formatParams={{count,max}} />
         </HorizBox>
     }
 }
@@ -389,7 +379,7 @@ export function checkValidLength({text, min, max}) {
 export function CircleCount({count}) {
     const s = CircleCountStyle;
     return <View style={s.circle}>
-        <UtilityText strong text={String(count)} />
+        <UtilityText weight='medium' text={String(count)} />
     </View>
 }
 const CircleCountStyle = StyleSheet.create({

--- a/client/component/text.js
+++ b/client/component/text.js
@@ -92,7 +92,6 @@ const DataVizTextStyle = StyleSheet.create({
         fontFamily: fontFamilyMonoRegular,
         fontSize: 12,
         lineHeight: 12 * 1.25,
-        fontStyle: 'italic'
     },
     number: {
         fontFamily: fontFamilyMonoSemiBold,

--- a/client/component/topbar.js
+++ b/client/component/topbar.js
@@ -126,9 +126,9 @@ export function FeatureTreeNode({featureBlock}) {
         const enabledCount = featureBlock.features.filter(isEnabled).length;
         const titleContent = <HorizBox center spread>
             {featureBlock.level == 2 ? 
-                <UtilityText type='tiny' caps strong label={featureBlock.label} />
+                <UtilityText type='tiny' caps weight='strong' label={featureBlock.label} />
             :
-                <UtilityText strong label={featureBlock.label} />
+                <UtilityText weight='medium' label={featureBlock.label} />
             }
             <Pad size={8} />
             {enabledCount ? <CircleCount count={enabledCount} /> : null}
@@ -188,7 +188,7 @@ function ChooseOneFeature({label, featureList}) {
         setChosenFeature(value);
     }
     return <View>
-        {label && <PadBox vert={12}><UtilityText strong caps type='tiny' label={label} /></PadBox>}
+        {label && <PadBox vert={12}><UtilityText weight='strong' caps type='tiny' label={label} /></PadBox>}
         <RadioGroup value={chosenFeature} onChange={onChange}>
             {featureList.map(f =>
                 <RadioOption key={f.key} radioKey={f.key} label={f.name} />

--- a/client/demo/designsystem-demo.js
+++ b/client/demo/designsystem-demo.js
@@ -96,12 +96,8 @@ function TextScreen() {
                 <EditorialHeading type='small' italic label='Editorial Heading Small Italic' />
             </DemoSection>
             <DemoSection label='DataViz Text'>
-                <DataVizText type='heading1' label='Data Viz Large' />
-                <DataVizText type='heading2' label='Data Viz Small' />
-                <DataVizText type='number' label='Data Viz Number' />
-                <DataVizText type='label' label='Data Viz Label' />
-                <DataVizText type='labelStrong' label='Data Viz Label Strong' />
-
+                <DataVizText type='heading1' label='Data viz heading large strong' />
+                <DataVizText type='heading2' label='Data viz heading small' />
             </DemoSection>
 
         </View>

--- a/client/demo/designsystem-demo.js
+++ b/client/demo/designsystem-demo.js
@@ -72,22 +72,22 @@ export const DesignSystemDemoFeature = {
 function TextScreen() {
     return <View>
             <DemoSection label='UI Text'>
-                <Heading label='Heading 1' level={1} />
-                <Heading label='Heading 2' level={2} />
+                <Heading label='Heading large medium' level={1} />
+                <Heading label='Heading small strong' level={2} />
                 <Paragraph type='large' label='Paragraph large' />
                 <Paragraph type='small' strong label='Paragraph small strong' />
                 <Paragraph type='small' label='Paragraph small' />
+                <UtilityText type='large' weight='medium' label='Utility large medium' />
                 <UtilityText type='large' label='Utility large' />
-                <UtilityText label='Utility small caps' caps strong />
-                <UtilityText strong label='Utility small strong' />
-                <UtilityText label='Utility small' />
-
-                <UtilityText color={colorTextGrey} label='Utility small color:TextGrey' />
-                <UtilityText underline label='Utility small Underline' />
-                
-                <UtilityText type='tiny' label='Utility tiny' />
-                <UtilityText type='tiny' strong label='Utility tiny strong' />
+                <UtilityText type='small' weight="medium" label='Utility small medium' />
+                <UtilityText type='small' label='Utility small' />
+                <UtilityText type='small' color={colorTextGrey} label='Utility small color:TextGrey' />
+                <UtilityText type='small' underline label='Utility small Underline' />
+                <UtilityText type='tiny' caps weight='medium' label='Utility tiny Caps medium' />
                 <UtilityText type='tiny' caps label='Utility tiny Caps' />
+                <UtilityText type='tiny' weight='strong' label='Utility tiny strong' />
+                <UtilityText type='tiny' weight='medium' label='Utility tiny medium' />
+                <UtilityText type='tiny' label='Utility tiny' />
             </DemoSection>
             <DemoSection label='Brand Text'>
                 <EditorialHeading label='Editorial Heading Large' />
@@ -96,8 +96,8 @@ function TextScreen() {
                 <EditorialHeading type='small' italic label='Editorial Heading Small Italic' />
             </DemoSection>
             <DemoSection label='DataViz Text'>
-                <DataVizText type='heading1' label='Data Viz Heading 1' />
-                <DataVizText type='heading2' label='Data Viz Heading 2' />
+                <DataVizText type='heading1' label='Data Viz Large' />
+                <DataVizText type='heading2' label='Data Viz Small' />
                 <DataVizText type='number' label='Data Viz Number' />
                 <DataVizText type='label' label='Data Viz Label' />
                 <DataVizText type='labelStrong' label='Data Viz Label Strong' />
@@ -269,12 +269,12 @@ function FormScreen() {
                 <UtilityText label='Selected: {value}' formatParams={{value: radioValue}} />
             </DemoSection>
             <DemoSection label='Accordion Field'>
-                <AccordionField titleContent={<UtilityText strong label='Title'/>}>
+                <AccordionField titleContent={<UtilityText weight='medium' label='Title'/>}>
                     <UtilityText label='Content' />
                 </AccordionField>
                 <AccordionField titleContent={
                         <HorizBox center>
-                            <UtilityText strong label='With Count'/>
+                            <UtilityText weight='medium' label='With Count'/>
                             <Pad size={8} />
                             <CircleCount count={3} />
                         </HorizBox>                        

--- a/client/feature/AdminUsersFeature.js
+++ b/client/feature/AdminUsersFeature.js
@@ -71,7 +71,7 @@ function AdminUser({adminUser}) {
         <HorizBox spread center>
             <View>
                 <UtilityText text={adminUser.email} />
-                {toBool(inProgress) && <UtilityText type='tiny' color={colorTextGrey} label='Updating roles...' />}
+                {toBool(inProgress) && <UtilityText type='tiny' weight='medium' color={colorTextGrey} label='Updating roles...' />}
             </View>
             <RoleSelectorPopup alignRight selectedRoles={roles ?? adminUser.roles} setSelectedRoles={setSelectedRoles} />
         </HorizBox>

--- a/client/feature/CloseConversationFeature.js
+++ b/client/feature/CloseConversationFeature.js
@@ -29,6 +29,6 @@ export function ClosedConversationBanner() {
             <UtilityText label={closedMessage} />            
         </Banner>
         {isAdmin && <Pad size={16} />}
-        {isAdmin && <UtilityText type='tiny' label='If you re-open this conversation, you will need to reload it (Admin)' />}
+        {isAdmin && <UtilityText type='tiny' weight='medium' label='If you re-open this conversation, you will need to reload it (Admin)' />}
     </View>
 }

--- a/client/feature/DemoFilter.js
+++ b/client/feature/DemoFilter.js
@@ -41,6 +41,6 @@ function CatToggle({comment, setComment}) {
 
 function CatState({comment}) {
     if (comment.isCat) {
-        return <PadBox bottom={10}><UtilityText strong label='Is a cat' /></PadBox>
+        return <PadBox bottom={10}><UtilityText weight='medium' label='Is a cat' /></PadBox>
     }
 }

--- a/client/structure/eventlog.js
+++ b/client/structure/eventlog.js
@@ -56,7 +56,7 @@ function EventType({eventType}) {
     const datastore = useDatastore();
     const [hover, setHover] = useState(false);
     return <HoverView setHover={setHover} onPress={() => datastore.pushSubscreen('eventlog', {eventType})}>
-        <UtilityText strong label={eventType} underline={hover} />
+        <UtilityText weight='medium' label={eventType} underline={hover} />
         <UtilityText color={colorTextGrey} label={eventTypes[eventType]} />
     </HoverView>
 }
@@ -198,7 +198,7 @@ function ExpandedEvent({event}) {
 function LinkedField({label, value, onPress}) {
     return <View>
         <HorizBox>
-            <UtilityText type='large' strong label={label + ': '} />
+            <UtilityText type='large' weight='medium' label={label + ': '} />
             {onPress && <TextButton onPress={onPress} text={value} />}
             {!onPress && <UtilityText type='large' text={value} />}
        </HorizBox>

--- a/client/system/componentdemo.js
+++ b/client/system/componentdemo.js
@@ -121,7 +121,7 @@ function DemoPageSection({search, label, screenKey, sections}) {
         {sections.map(section => 
             (!search || section.pages.some(page => page.label.toLowerCase().includes(search.toLowerCase()))) &&
                 <AccordionField key={section.label} forceOpen={toBool(search)}
-                    titleContent={<UtilityText strong label={section.label} />} >
+                    titleContent={<UtilityText weight='medium' label={section.label} />} >
                     <FlowBox>
                         {sortBy(section.pages, 'label').map((page, j) => 
                             page.label.toLowerCase().includes(search.toLowerCase()) &&

--- a/client/system/demo.js
+++ b/client/system/demo.js
@@ -230,12 +230,12 @@ export function NavResult({navInstance}) {
     return <PadBox horiz={8} vert={8}>
         <Banner>
             <UtilityText text='Navigated to:' />
-            {navInstance.close && <UtilityText strong text='Close window' />}
-            {navInstance.url && <UtilityText strong text={navInstance.url} />}
-            {navInstance.parent && <UtilityText strong text='Parent screen' />}
-            {navInstance.structureKey && <UtilityText strong text={navInstance.structureKey + '/' + navInstance.instanceKey} />}
-            {navInstance.screenKey && <UtilityText strong text={'Subscreen: ' + navInstance.screenKey + '(' + JSON.stringify(navInstance.params) + ')'} />}
-            {navInstance.token && <UtilityText strong text={'Login token: ' + navInstance.token} />}
+            {navInstance.close && <UtilityText weight='medium' text='Close window' />}
+            {navInstance.url && <UtilityText weight='medium' text={navInstance.url} />}
+            {navInstance.parent && <UtilityText weight='medium' text='Parent screen' />}
+            {navInstance.structureKey && <UtilityText weight='medium' text={navInstance.structureKey + '/' + navInstance.instanceKey} />}
+            {navInstance.screenKey && <UtilityText weight='medium' text={'Subscreen: ' + navInstance.screenKey + '(' + JSON.stringify(navInstance.params) + ')'} />}
+            {navInstance.token && <UtilityText weight='medium' text={'Login token: ' + navInstance.token} />}
         </Banner>
     </PadBox>
 }
@@ -244,7 +244,7 @@ export function ServerCallLog({callLog}) {
     const s = ServerCallLogStyle;
     return <View style={s.callList}>
         {callLog.map((call, i) => 
-            <UtilityText type='tiny' color={colorTextGrey} key={i} text={call.component + '.' + call.funcname + '(' + JSON.stringify(call.params) +')'} />
+            <UtilityText type='tiny' weight='medium' color={colorTextGrey} key={i} text={call.component + '.' + call.funcname + '(' + JSON.stringify(call.params) +')'} />
         )}
     </View>
 }

--- a/client/system/migrations.js
+++ b/client/system/migrations.js
@@ -92,8 +92,8 @@ function MigrationScreen({migrationKey}) {
                 <CTAButton type='secondary' text='Past Executions' onPress={() => datastore.pushSubscreen('past', {migrationKey})} />
             </HorizBox>
         }
-        {inProgress && <UtilityText strong label='Migration in progress...' />}
-        {done && <UtilityText strong label='Migration complete' />}
+        {inProgress && <UtilityText weight='medium' label='Migration in progress...' />}
+        {done && <UtilityText weight='medium' label='Migration complete' />}
         <Pad />
         {migrationLog && <MigrationLog migrationLog={migrationLog} />}
         {forwardWrites && <MigrationChanges newMap={forwardWrites} oldMap={undoWrites} />}
@@ -124,7 +124,7 @@ function PastExecutions({migrationKey}) {
                     oldMap={JSON.parse(pastExecutions[key].undoWrites)} 
                 />
                 <Pad size={8} />
-                {pastExecutions[key].rolledBack && <UtilityText strong text='Rolled back' />}
+                {pastExecutions[key].rolledBack && <UtilityText weight='medium' text='Rolled back' />}
                 {mostRecentKey == key && !pastExecutions[key].rolledBack && <CTAButton text='Roll Back Migration' onPress={() => onRollBack(key)} />}
             </AccordionField>
         )}
@@ -157,7 +157,7 @@ function MigrationChanges({newMap, oldMap}) {
             <PadBox horiz={8} vert={4}>
                 {keys.map(key =>
                     <View key={key}> 
-                        <UtilityText strong text={key} />
+                        <UtilityText weight='medium' text={key} />
                         <PadBox left={20}>
                             <UtilityText text={'New: ' + stringifySorted(newMap[key])} />
                             <UtilityText text={'Old: ' + stringifySorted(oldMap[key])} />                            


### PR DESCRIPTION
https://github.com/wearenewpublic/psi-product/issues/169

Decouples the size and weight properties in UtiltityText so that each may be easily set independently of the other. It was also confusing before because the `strong` property also affected weight as well. So I got rid of this and made one prop, `weight` which is responsible for setting weight.

 Made this change to make it more clear for developers how to set weight (since strong could mean different things depending on size and different sizes also did not have consistent weights) but also because the design system wants to support various weights for all the sizes and it's easier to do that with this change.

Because I changed the interface of UtilityText by removing strong, I did have to go through and update many files. Pretty sure I got close to everything, but let Tori know there may be some things I missed and she's OK with that if it means the system is more scalable. For reference these were the changes I made for all the implementations of UtilityText throughout the codebase:

Previously: type=’large’ strong
Now: weight=’medium’

Previously: type=small’ strong
Now: weight=’medium’

Previously: type=’tiny’ strong
Now: type=’tiny’ weight=’strong’

Previously: type=’tiny’
Now: type=’tiny’ weight=’medium
