### PR TITLE
Updating Heading to align with the design system

### DIFF
--- a/client/component/button.js
+++ b/client/component/button.js
@@ -182,7 +182,7 @@ const SubtleButtonStyle = StyleSheet.create({
 });
 
 
-export function TextButton({label, text, level=1, type='large', heading=false, paragraph=false, editorial=false, underline, strong, italic, formatParams, leftIcon, leftIconProps={}, rightIcon, rightIconProps={}, color=colorBlack, alignStart=false, onPress}) {
+export function TextButton({label, text, type='large', heading=false, paragraph=false, editorial=false, underline, strong, italic, formatParams, leftIcon, leftIconProps={}, rightIcon, rightIconProps={}, color=colorBlack, alignStart=false, onPress}) {
     const s = TextButtonStyle;
     const [hover, setHover] = useState(false);
     return <HoverView shrink testID={label ?? text}

--- a/client/component/button.js
+++ b/client/component/button.js
@@ -197,8 +197,8 @@ export function TextButton({label, text, level=1, type='large', heading=false, p
             <EditorialHeading type={type} label={label} text={text} formatParams={formatParams}
                 color={color} underline={hover ^ underline} italic={italic} strong={strong} />
         : heading ?
-            <Heading label={label} text={text} formatParams={formatParams} level={level}
-                color={color} underline={hover ^ underline} strong={strong} />
+            <Heading label={label} text={text} formatParams={formatParams} type={type}
+                color={color} underline={hover ^ underline} weight={strong ? 'medium' : 'regular'} />
         :
             <UtilityText label={label} text={text} formatParams={formatParams} type={type} 
                 color={color} underline={hover ^ underline} weight={strong ? 'medium' : 'regular'} />

--- a/client/component/comment.js
+++ b/client/component/comment.js
@@ -309,7 +309,7 @@ function DeleteModal({onDelete, onClose}) {
     }
     return <Modal onClose={onClose}>
         <PadBox horiz={20} vert={40}>
-            <Heading level={1} label='Delete this post?' />
+            <Heading type="large" weight="medium" label='Delete this post?' />
             <Pad size={8} />
             <UtilityText label="This action can't be undone"/>
             <Pad size={32} />

--- a/client/component/help.js
+++ b/client/component/help.js
@@ -96,7 +96,7 @@ export function NoCommentsHelp() {
             <Image source={{uri: makeAssetUrl('images/bubbles.png') }}
                 style={{width: 58, height: 58}} />    
             <View style={s.right}>
-                <Heading level={2} label={noCommentsTitle} />
+                <Heading label={noCommentsTitle} />
                 <Pad size={4} />
                 <RichText label={noCommentsMessage} />
             </View>

--- a/client/component/text.js
+++ b/client/component/text.js
@@ -14,52 +14,39 @@ const fontFamilySansMedium = 'IBMPlexSans_500Medium, Arial, Helvetica, sans-seri
 const fontFamilySansSemiBold = 'IBMPlexSans_600SemiBold, Arial, Helvetica, sans-serif';
 const fontFamilyMonoRegular = 'IBMPlexMono_400Regular, Arial, Helvetica, sans-serif';
 const fontFamilyMonoMedium = 'IBMPlexMono_500Medium, Arial, Helvetica, sans-serif';
-const fontFamilyMonoSemiBold = 'IBMPlexMono_600SemiBold, Arial, Helvetica, sans-serif'
+const fontFamilyMonoSemiBold = 'IBMPlexMono_600SemiBold, Arial, Helvetica, sans-serif';
 
-export function Heading({text, color={color}, center, label, level=2, underline=false, formatParams}) {
-    const styleMap = {
-        1: HeadingStyle.heading1,
-        2: HeadingStyle.heading2,
-        3: HeadingStyle.heading3,
-        4: HeadingStyle.heading4,
-        5: HeadingStyle.heading5,
+export function Heading({text, weight='strong', type='small', color={color}, center, label, underline=false, formatParams}) {
+    const weightMap = {
+        regular: fontFamilySansRegular,
+        medium: fontFamilySansMedium,
+        strong: fontFamilySansSemiBold,
+    } 
+    const sizeMap = {
+        large: HeadingStyle.large,
+        small: HeadingStyle.small,
     }
-    return <TranslatableText text={text} aria-level={level} role='heading' label={label} formatParams={formatParams} 
+    const ariaMap = {
+        large: '1',
+        small: '2',
+    }
+    return <TranslatableText text={text} aria-level={ariaMap[type]} role='heading' label={label} formatParams={formatParams} 
         style={[
-            styleMap[level], 
+            sizeMap[type], weightMap[weight],
             underline && {textDecorationLine: 'underline'},
             center ? {textAlign: 'center'} : null, {color}
         ]} />
 }
 
 const HeadingStyle = StyleSheet.create({
-    heading1: {
-        fontFamily: fontFamilySansMedium,
+    large: {
         fontSize: 24,
         lineHeight: 24 * 1.25
-    },
-    heading2: {
-        fontFamily: fontFamilySansSemiBold,
+    },    
+    small: {
         fontSize: 16,
         lineHeight: 16 * 1.25
-    },
-    heading3: {
-        fontFamily: fontFamilySansMedium,
-        fontSize: 14,
-        lineHeight: 14 * 1.25
-    },
-    heading4: {
-        fontFamily: fontFamilyMonoRegular,
-        fontSize: 12,
-        lineHeight: 12 * 1.25,
-        fontStyle: 'italic',
-    },
-    heading5: {
-        fontFamily: fontFamilySansRegular,
-        fontSize: 14,
-        lineHeight: 14 * 1.25,
-    },
-    
+    },    
 })
 
 export function DataVizText({type, text, label, formatParams}) {
@@ -164,7 +151,7 @@ const ParagraphStyle = StyleSheet.create({
 
 
 
-export function UtilityText({type='small', center=false, right=false, text, label, formatParams, color='black', weight='regular', caps=false, underline=false, numberOfLines=null, ellipsizeMode='tail'}) {
+export function UtilityText({type='small', center=false, right=false, text, label, formatParams, color='black', weight='regular', caps=false, underline=false, numberOfLines=null, ellipsizeMode='tail', italic=false, mono=false}) {
     const s = UtilityTextStyle;
     const styleMap = {
         large: s.utilityLarge,
@@ -176,13 +163,19 @@ export function UtilityText({type='small', center=false, right=false, text, labe
         medium: fontFamilySansMedium,
         strong: fontFamilySansSemiBold,
     }
+    const monoWeightMap = {
+        regular: fontFamilyMonoRegular,
+        medium: fontFamilyMonoMedium,
+        strong: fontFamilyMonoSemiBold,
+    }    
     if (!text && !label) return null;
     return <TranslatableText text={text} label={label} role="paragraph" formatParams={formatParams}
         numberOfLines={numberOfLines} ellipsizeMode={ellipsizeMode}
         style={[
             styleMap[type], {color}, 
+            italic && {fontStyle: 'italic'},
             underline && {textDecorationLine: 'underline'},
-            weight && {fontFamily: weightMap[weight]},
+            weight && {fontFamily: mono ? monoWeightMap[weight] : weightMap[weight]},
             center && {textAlign: 'center'},
             right && {textAlign: 'right'},
             caps && {textTransform: 'uppercase', letterSpacing: 0.5}
@@ -220,14 +213,14 @@ export function LinkText({type='small', testID, text, url, label, formatParams})
     </WebLink>
 }
 
-export function WebLinkTextButton({label, heading, level, text, url, type}) {
+export function WebLinkTextButton({label, heading, text, url, type, weight='regular'}) {
     const s = WebLinkTextButtonStyle;
     const [hover, setHover] = useState(false);
     return <WebLink testID={label ?? text} url={url} style={hover ? s.hoverButton : s.button} setHover={setHover}>
         {heading ? 
-            <Heading label={label} text={text} level={level} /> 
+            <Heading label={label} text={text} type={type} weight={weight} /> 
         : 
-            <UtilityText label={label} text={text} type={type} />
+            <UtilityText label={label} text={text} type={type} weight={weight} />
         }
     </WebLink>
 }

--- a/client/demo/designsystem-demo.js
+++ b/client/demo/designsystem-demo.js
@@ -72,8 +72,8 @@ export const DesignSystemDemoFeature = {
 function TextScreen() {
     return <View>
             <DemoSection label='UI Text'>
-                <Heading label='Heading large medium' level={1} />
-                <Heading label='Heading small strong' level={2} />
+                <Heading label='Heading large medium' type="large" weight="medium" />
+                <Heading label='Heading small strong' />
                 <Paragraph type='large' label='Paragraph large' />
                 <Paragraph type='small' strong label='Paragraph small strong' />
                 <Paragraph type='small' label='Paragraph small' />

--- a/client/feature/AdminUsersFeature.js
+++ b/client/feature/AdminUsersFeature.js
@@ -36,7 +36,7 @@ export function AdminUsersScreen() {
 
     return <ConversationScreen pad>
         <Pad />
-        <Heading level={1} label='Admin Users' />
+        <Heading type="large" weight="medium" label='Admin Users' />
         <Pad />
         <AdminUserList adminUsers={adminUsers} />
         <Pad />   

--- a/client/feature/CloseConversationFeature.js
+++ b/client/feature/CloseConversationFeature.js
@@ -24,7 +24,7 @@ export function ClosedConversationBanner() {
     const isAdmin = useIsAdmin();
     return <View>
         <Banner color={colorPink}>
-            <Heading level={2} label={closedTitle} />
+            <Heading label={closedTitle} />
             <Pad size={16} />
             <UtilityText label={closedMessage} />            
         </Banner>

--- a/client/feature/ProfileCommentsFeature.js
+++ b/client/feature/ProfileCommentsFeature.js
@@ -25,7 +25,7 @@ function ProfileCommentsWidget() {
     const comments = useDerivedCollection('comment');
 
     return <PadBox top={20}>
-        <Heading level='1' label='Comments' />
+        <Heading type="large" weight="medium" label='Comments' />
         {comments.map(comment => <DerivedComment key={comment.key} comment={comment} />)}
     </PadBox>    
 }

--- a/client/feature/ProfilePhotoAndName.js
+++ b/client/feature/ProfilePhotoAndName.js
@@ -44,7 +44,7 @@ function ViewPhotoAndName() {
         <HorizBox center>
             <ProfilePhoto userId={personaKey} type='huge' />
             <Pad />      
-            <Heading level={1} text={persona.name} />            
+            <Heading type="large" weight="medium" text={persona.name} />            
         </HorizBox>
     </View>
 }
@@ -65,7 +65,7 @@ function EditPhotoAndName() {
     }
 
     return <View>
-        <Heading level={3} label='Profile name'/>
+        <UtilityText weight='medium' label='Profile name'/>
         <Pad size={8} />
         <RadioGroup value={nameMode} onChange={onChangeNameMode}>
             <RadioOption radioKey='full' text={fbUser.displayName} />
@@ -74,7 +74,7 @@ function EditPhotoAndName() {
         {nameMode == 'custom' && <Catcher><PseudonymEditor /></Catcher>}
         {fbUser.photoURL &&
             <PadBox top={32}>
-                <Heading level={3} label='Your profile photo'/>
+                <UtilityText weight='medium' label='Your profile photo'/>
                 <Pad size={12} />
                 <Catcher><ProfilePhotoEditor /></Catcher>
             </PadBox>
@@ -209,7 +209,7 @@ export function FirstLoginSetup({onFieldsChosen}) {
 
     return <View>
         <PadBox horiz={20} vert={20}>
-            <Heading level={1} label="Let's get your profile set up" />
+            <Heading type="large" weight="medium" label="Let's get your profile set up" />
             <Pad size={8} />
             <Paragraph type='large' label='How do you want to appear to others in your posts and replies?' />
             <Pad size={40} />

--- a/client/structure/admin.js
+++ b/client/structure/admin.js
@@ -29,9 +29,9 @@ export function AdminScreen() {
 
     return <ConversationScreen pad>
         <Pad/>
-        <Heading level={1} label='Admin Dashboard' />
+        <Heading type="large" weight="medium" label='Admin Dashboard' />
         <Pad />
-        <Heading level={2} label='Quick Links' />
+        <Heading label='Quick Links' />
         <FlowBox>
             {quickLinks?.map(quickLink => <PadBox top={8} right={8} key={quickLink.label}>
                 <QuickLink quickLink={quickLink} />

--- a/client/structure/eventlog.js
+++ b/client/structure/eventlog.js
@@ -34,7 +34,7 @@ function HomeScreen() {
     return <RestrictedScreen capability='eventlog/view'>
         <WindowTitle title='Log Dashboard' />
         <Pad />
-        <Heading level={1} label='Logs Dashboard' />
+        <Heading type="large" weight="medium" label='Logs Dashboard' />
         <Pad />
         <CTAButton label='Sessions' onPress={() => datastore.pushSubscreen('sessions')}/>
         <Pad />
@@ -46,7 +46,7 @@ export function EventTypesScreen() {
     return <RestrictedScreen capability='eventlog/view'>
         <WindowTitle title='Event Types' />
         <Pad />
-        <Heading level={1} label='Event Types' />
+        <Heading type="large" weight="medium" label='Event Types' />
         <Pad />
         {Object.keys(eventTypes).map((eventType, i) => <PadBox vert={4} key={i}><EventType eventType={eventType} /></PadBox>)}
     </RestrictedScreen>
@@ -81,7 +81,7 @@ export function SessionListScreen() {
         <WindowTitle title='Sessions' />
         <Pad />
         <HorizBox spread center>
-            <Heading level={1} label='Sessions' />
+            <Heading type="large" weight="medium" label='Sessions' />
             <CTAButton label='Refresh' onPress={onRefresh} />
         </HorizBox>
         <Pad />
@@ -137,7 +137,7 @@ export function EventLogScreen({eventType, sessionKey, siloKey}) {
         <Pad />
         {sessionKey && <PadBox bottom={20}><SessionSummary sessionKey={sessionKey} /></PadBox>}
         <HorizBox spread center>
-            <Heading level={1} label='Event Log' />
+            <Heading type="large" weight="medium" label='Event Log' />
             <CTAButton label='Refresh' onPress={onRefresh} />
         </HorizBox>
         <Pad />

--- a/client/structure/login.js
+++ b/client/structure/login.js
@@ -80,17 +80,17 @@ export function UnauthenticatedLoginScreen({action, showGithub=true, showGoogle=
     const [bubbleHeight, setBubbleHeight] = useState(0);
     return <View style={s.outer}>
         <Pad size={40} />        
-        <Heading level='1' center label={'Join the discussion' + (action ? ' to ' + action : '')} />
+        <Heading type="large" weight="medium" center label={'Join the discussion' + (action ? ' to ' + action : '')} />
         <Pad size={4}/>
         <View style={s.subHeadWrapper}>
-            <Heading level='5' center label={"Once you log in, enter a display name"} />
+            <UtilityText center label={"Once you log in, enter a display name"} />
         </View>
         <Pad size={52} />
         <View style={s.imageWrapper}>
             <View style={[s.bubble, { top: -(bubbleHeight / 2) }]}
             onLayout={(event) => setBubbleHeight(event.nativeEvent.layout.height)}>
                 <PadBox>
-                <Heading level='3' center color={colorWhite} label={'Add your display name'} />
+                <UtilityText weight='medium' center color={colorWhite} label={'Add your display name'} />
                 </PadBox>
             </View> 
             <Image source={{ uri: makeAssetUrl("images/set_visibility_image.png") }} style={{ width: 250, height: 160 }} />

--- a/client/structure/simplecomments.js
+++ b/client/structure/simplecomments.js
@@ -78,7 +78,7 @@ function SimpleCommentsScreen() {
         {topBanners?.map((Banner, i) => <Banner key={i} />)}
         <HeaderBox>
             <HeaderTopWidgets />
-            <Heading level={1} label='Comments'/>
+            <Heading type="large" weight="medium" label='Comments'/>
             <Pad />
             {React.createElement(composerPreview)}
         </HeaderBox>

--- a/client/system/componentdemo.js
+++ b/client/system/componentdemo.js
@@ -75,7 +75,7 @@ function ComponentPageScreen({pageKey}) {
 
     return <ConversationScreen>
         <HeaderBox backgroundColor={colorGreyPopupBackground}>
-            <Heading level={1} label={page.label} />
+            <Heading type="large" weight="medium" label={page.label} />
             <Pad size={8} />
             {designUrl && <LinkText label='Design Link' url={designUrl} />}
             {!designUrl && <UtilityText color={colorRed} label='No design link' />}
@@ -117,7 +117,7 @@ function DemoPageSection({search, label, screenKey, sections}) {
     const datastore = useDatastore();
 
     return <View>
-        <Heading level={1} label={label} />
+        <Heading type="large" weight="medium" label={label} />
         {sections.map(section => 
             (!search || section.pages.some(page => page.label.toLowerCase().includes(search.toLowerCase()))) &&
                 <AccordionField key={section.label} forceOpen={toBool(search)}

--- a/client/system/demo.js
+++ b/client/system/demo.js
@@ -38,7 +38,7 @@ export function CHECK_TEXT(expectedText) {
 export function DemoSection({label, horiz=false, children, color=null}) {
     const s = DemoSectionStyle;
     return <View style={{marginBottom: 32}}>
-        <Heading type='small' label={label} />
+        <Heading label={label} />
         <Pad size={8} />
         <View style={[s.box, color && {backgroundColor: color}]}>
             <Catcher>
@@ -199,7 +199,7 @@ export function DemoStorySet({storySet}) {
             closeWindow={() => setNavInstance({close: true})}
             pushSubscreen={(screenKey,params) => setNavInstance({screenKey, params})}
             serverCall={{...defaultServerCall, ...serverCall}} >
-        <Heading type='small' text={storySet.label} />
+        <Heading text={storySet.label} />
         <Pad size={5} />
         <FlowBox>
             {storySet.stories?.map(story =>


### PR DESCRIPTION
- As requested, limits usage of Heading in the codebase to "Heading large medium" and "Heading small strong", elimiating levels 3, 4, and 5
- To accommodate the above change, modifies UtilityText to accept mono and italics and updated old implementations that used levels 3, 4, 5 to use UtilityText instead
- Makes the Heading interface consistent with UtilityText by getting rid of the `level` prop and adding `weight` and `type` props
- Updates usage of Heading throughout the codebase to be consistent with these changes
- Had to update the WebLInkTextButton and TextButton components (which themselves can creating Headings) to be consistent with this change too and stop using `level`