### PR TITLE
Accessibility changes to Comment

### DIFF
--- a/client/component/comment.js
+++ b/client/component/comment.js
@@ -32,20 +32,18 @@ export function Comment({commentKey}) {
             </Catcher>
             <Byline type='large' userId={comment.from} time={comment.time} edited={comment.edited} />
             <Pad size={20} />
-            <PadBox left={48}>
-                <Catcher>
-                    <CommentBody commentKey={commentKey} />
-                </Catcher>
-                <Catcher>
-                    {commentMiddleWidgets?.map((Widget,i) => <Widget key={i} comment={comment}/>)}
-                </Catcher>                
-                <Catcher>
-                    {commentBelowWidgets?.map((Widget,i) => <Widget key={i} comment={comment}/>)}
-                </Catcher>
-                {!editing && <PadBox top={20}><Catcher><CommentActions commentKey={commentKey} /></Catcher></PadBox>}
-                <MaybeCommentReply commentKey={commentKey} />
-                <CommentReplies commentKey={commentKey} />
-            </PadBox>
+            <Catcher>
+                <CommentBody commentKey={commentKey} />
+            </Catcher>
+            <Catcher>
+                {commentMiddleWidgets?.map((Widget,i) => <Widget key={i} comment={comment}/>)}
+            </Catcher>                
+            <Catcher>
+                {commentBelowWidgets?.map((Widget,i) => <Widget key={i} comment={comment}/>)}
+            </Catcher>
+            {!editing && <PadBox top={20}><Catcher><CommentActions commentKey={commentKey} /></Catcher></PadBox>}
+            <MaybeCommentReply commentKey={commentKey} />
+            <CommentReplies commentKey={commentKey} />
         </PadBox>
         <PadBox horiz={20}><Separator /></PadBox>
     </View>

--- a/client/component/comment.js
+++ b/client/component/comment.js
@@ -111,7 +111,7 @@ export function CommentBody({commentKey}) {
         return <View style={commentBodyStyle}>
             {commentTopWidgets?.map((Widget,i) => <Widget key={i} comment={comment}/>)}
             <RichText numberOfLines={(isLong && !expanded) ? 8 : null} 
-                text={text.trim()} color={commentBodyStyle.color}
+                text={text.trim()} color={commentBodyStyle.color} type='large'
             />
             {isLong && !expanded && <PadBox top={14}><TextButton underline type='small' label='Read more' onPress={() => setExpanded(true)} /></PadBox>}
         </View>


### PR DESCRIPTION
From Tori:

- Size of the body text on a Comment/Reply is now "Paragraph large" (so 16px instead of 14px)
- To accommodate this, I've reduced the left indentations: A top-level comment isn't indented, a first-level reply's body is indented, and a second-level reply is more indented (please inspect the Figma)

Before Version Design:
<img width="330" alt="Screenshot 2024-11-18 at 8 34 14 AM" src="https://github.com/user-attachments/assets/1852ccfb-5877-47db-9d1e-c17bc9c86771">


After Version Design:
<img width="285" alt="Screenshot 2024-11-18 at 8 33 35 AM" src="https://github.com/user-attachments/assets/5c10a18b-9346-4c0f-8417-c69d6166d612">
