### PR TITLE
Update Byline Design

### DIFF
--- a/client/component/button.js
+++ b/client/component/button.js
@@ -201,7 +201,7 @@ export function TextButton({label, text, level=1, type='large', heading=false, p
                 color={color} underline={hover ^ underline} strong={strong} />
         :
             <UtilityText label={label} text={text} formatParams={formatParams} type={type} 
-                color={color} underline={hover ^ underline} strong={strong} />
+                color={color} underline={hover ^ underline} weight={strong ? 'medium' : 'regular'} />
         }
         {rightIcon && <Pad size={8} />}
         {rightIcon && React.createElement(rightIcon, {...rightIconProps, color})}
@@ -278,7 +278,7 @@ export function Tag({label, emoji, text, type='emphasized', strong=false, format
         {emoji && <PadBox right={6}><UtilityText text={emoji} type='tiny' weight='strong' /></PadBox>}
         <UtilityText color={type=='tiny' ? colorTextBlue : null} 
             label={label} text={text} formatParams={formatParams} 
-            strong={strong} type='tiny' weight='medium' />
+            type='tiny' weight={strong ? 'strong' : 'medium'} />
     </View>
 }
 const TagStyle = StyleSheet.create({
@@ -298,7 +298,7 @@ const TagStyle = StyleSheet.create({
         borderRadius: 100,
     },
     tiny: {
-        paddingHorizontal: 4,
+        paddingHorizontal: 6,
         paddingVertical: 2,
         borderRadius: 100,
         height: 20,

--- a/client/component/button.js
+++ b/client/component/button.js
@@ -237,7 +237,7 @@ export function TextLinkButton({label, text, type='large', paragraph=false, edit
 
 
 export function ExpandButton({
-        userList, photoUrlList, label, text, type='small', 
+        userList, photoUrlList, label, text, type='tiny', 
         formatParams, expanded, setExpanded=()=>{},
         testID,
     }) {

--- a/client/component/comment.js
+++ b/client/component/comment.js
@@ -59,7 +59,7 @@ export function ReplyComment({commentKey, depth={depth}, isFinal=false}) {
     const style = getCombinedStyle({comment, stylers:commentStylers});
     return <View testID={commentKey} id={commentKey} style={[depth == 1 ? s.firstLevel : s.secondLevel, style]}>
         <Catcher>{replyAboveWidgets?.map((Widget,i) => <Widget key={i} comment={comment}/>)}</Catcher>
-        <Byline type='abbreviated' userId={comment.from} time={comment.time} edited={comment.edited} />
+        <Byline type={depth == 1 ? 'small' : 'tiny'} userId={comment.from} time={comment.time} edited={comment.edited} />
         <Pad size={20} />
         <PadBox left={40}>
             <CommentBody commentKey={commentKey} />
@@ -155,7 +155,7 @@ function MaybeCommentReply({commentKey}) {
 
     return <View>
         <Pad size={20} />
-        <Byline type='abbreviated' userId={personaKey} />
+        <Byline type='small' userId={personaKey} showMetadata={false} />
         <Pad size={20} />
         <PadBox left={24}>
             <EditComment comment={comment} onCancel={onCancel}

--- a/client/component/comment.js
+++ b/client/component/comment.js
@@ -59,7 +59,7 @@ export function ReplyComment({commentKey, depth={depth}, isFinal=false}) {
     const style = getCombinedStyle({comment, stylers:commentStylers});
     return <View testID={commentKey} id={commentKey} style={[depth == 1 ? s.firstLevel : s.secondLevel, style]}>
         <Catcher>{replyAboveWidgets?.map((Widget,i) => <Widget key={i} comment={comment}/>)}</Catcher>
-        <Byline type='small' userId={comment.from} time={comment.time} edited={comment.edited} />
+        <Byline type='abbreviated' userId={comment.from} time={comment.time} edited={comment.edited} />
         <Pad size={20} />
         <PadBox left={40}>
             <CommentBody commentKey={commentKey} />
@@ -155,7 +155,7 @@ function MaybeCommentReply({commentKey}) {
 
     return <View>
         <Pad size={20} />
-        <Byline type='small' userId={personaKey} />
+        <Byline type='abbreviated' userId={personaKey} />
         <Pad size={20} />
         <PadBox left={24}>
             <EditComment comment={comment} onCancel={onCancel}

--- a/client/component/people.js
+++ b/client/component/people.js
@@ -245,8 +245,7 @@ const sizeMap = {
     huge: 80,
     large: 40,
     small: 32,
-    tiny: 24,
-    abbreviated: 24,
+    tiny: 24
 }
 
 const checkPadMap = {

--- a/client/component/people.js
+++ b/client/component/people.js
@@ -168,7 +168,7 @@ export function BylineMetadata({userId, time, edited=false}) {
     </View>
 }
 
-export function Byline({ type = 'small', clickable = true, userId, name = null, photo = null, time, underline = false, edited = false, showMetadata = true }) {
+export function Byline({ type = 'small', clickable = true, userId, name = null, photo = null, time, underline = false, edited = false, subtitleLabel, subtitleParams = {}, showMetadata = true }) {
     const s = BylineStyle;
     const persona = usePersonaObject(userId);
     const datastore = useDatastore();
@@ -185,7 +185,8 @@ export function Byline({ type = 'small', clickable = true, userId, name = null, 
             :
                 <UtilityText weight='medium' text={name ?? persona?.name} underline={underline} />
             }
-            {showMetadata && <View>
+            {subtitleLabel && <UtilityText color={colorTextGrey} label={subtitleLabel} formatParams={subtitleParams} underline={underline} />}
+            {!subtitleLabel && showMetadata && <View>
                 <Pad size={2} />
                 <BylineMetadata userId={userId} time={time} edited={edited} />
             </View>}

--- a/client/component/people.js
+++ b/client/component/people.js
@@ -151,7 +151,7 @@ const TagRowStyle = StyleSheet.create({
     },
 });
 
-export function BylineMetaData({userId, time, edited=false, abbreviated=false}) {
+export function BylineMetadata({userId, time, edited=false, abbreviated=false}) {
     const { bylineTags } = useConfig();
     const language = useLanguage();
     const persona = usePersonaObject(userId);
@@ -186,10 +186,11 @@ export function Byline({ type = 'small', clickable = true, userId, name = null, 
                 <UtilityText weight='medium' text={name ?? persona?.name} underline={underline} />
             }
             <Pad size={type === 'abbreviated' ? 6 : 2} />
-            <BylineMetaData userId={userId} time={time} edited={edited} abbreviated={type == 'abbreviated'}/>
+            <BylineMetadata userId={userId} time={time} edited={edited} abbreviated={type == 'abbreviated'}/>
         </View>
     </View>
 }
+
 
 const BylineStyle = StyleSheet.create({
     outer: {

--- a/client/component/people.js
+++ b/client/component/people.js
@@ -151,7 +151,7 @@ const TagRowStyle = StyleSheet.create({
     },
 });
 
-export function BylineMetadata({userId, time, edited=false, abbreviated=false}) {
+export function BylineMetadata({userId, time, edited=false}) {
     const { bylineTags } = useConfig();
     const language = useLanguage();
     const persona = usePersonaObject(userId);
@@ -163,12 +163,12 @@ export function BylineMetadata({userId, time, edited=false, abbreviated=false}) 
         {hasTags && <TagRow tags={[tags[0]]} />}
         {time && <UtilityText type='tiny' color={colorTextGrey}
             label={(hasTags ? ' • ' : '') + '{time}' + (edited ? ' • Edited' : '')}
-            formatParams={abbreviated ? {time: formatMiniDate(time, language)} : {time: formatDate(time, language)}}
+            formatParams={{time: formatDate(time, language)}}
         />}
     </View>
 }
 
-export function Byline({ type = 'small', clickable = true, userId, name = null, photo = null, time, underline = false, edited = false }) {
+export function Byline({ type = 'small', clickable = true, userId, name = null, photo = null, time, underline = false, edited = false, showMetadata = true }) {
     const s = BylineStyle;
     const persona = usePersonaObject(userId);
     const datastore = useDatastore();
@@ -179,14 +179,16 @@ export function Byline({ type = 'small', clickable = true, userId, name = null, 
     return <View style={s.outer}>
         <ProfilePhoto userId={userId} photo={photo} type={type} />
         <Pad size={spacings.xs} />
-        <View style={{ flexDirection: type === 'abbreviated' ? 'row' : 'column' }}>
+        <View style={{ flexDirection: 'column' }}>
             {clickable ?
                 <TextButton type='small' strong text={name ?? persona?.name} underline={underline} onPress={onProfile} />
             :
                 <UtilityText weight='medium' text={name ?? persona?.name} underline={underline} />
             }
-            <Pad size={type === 'abbreviated' ? 6 : 2} />
-            <BylineMetadata userId={userId} time={time} edited={edited} abbreviated={type == 'abbreviated'}/>
+            {showMetadata && <View>
+                <Pad size={2} />
+                <BylineMetadata userId={userId} time={time} edited={edited} />
+            </View>}
         </View>
     </View>
 }

--- a/client/component/people.js
+++ b/client/component/people.js
@@ -149,46 +149,47 @@ const TagRowStyle = StyleSheet.create({
         flexDirection: 'row',
         alignItems: 'center',
     },
-    tag: {
-        marginRight: 4,
-    }
 });
 
-export function Byline({ type = 'small', photoType = null, clickable = true, userId, name = null, photo = null, time, subtitleLabel, subtitleParams = {}, underline = false, edited = false }) {
-
+export function BylineMetaData({userId, time, edited=false, abbreviated=false}) {
     const { bylineTags } = useConfig();
-    const s = BylineStyle;
-    const persona = usePersonaObject(userId);
     const language = useLanguage();
-    const datastore = useDatastore();
+    const persona = usePersonaObject(userId);
     const tags = bylineTags?.map(tagFunc => tagFunc(persona)).filter(tag => tag);
     const hasTags = tags?.length > 0;
+
+    // TODO: Support more than one tag when there are designs for that
+    return <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+        {hasTags && <TagRow tags={[tags[0]]} />}
+        {time && <UtilityText type='tiny' color={colorTextGrey}
+            label={(hasTags ? ' • ' : '') + '{time}' + (edited ? ' • Edited' : '')}
+            formatParams={abbreviated ? {time: formatMiniDate(time, language)} : {time: formatDate(time, language)}}
+        />}
+    </View>
+}
+
+export function Byline({ type = 'small', clickable = true, userId, name = null, photo = null, time, underline = false, edited = false }) {
+    const s = BylineStyle;
+    const persona = usePersonaObject(userId);
+    const datastore = useDatastore();
 
     function onProfile() {
         datastore.gotoInstance({ structureKey: 'profile', instanceKey: userId });
     }
-    const oneLine = hasTags || type == 'small';
     return <View style={s.outer}>
-        <ProfilePhoto userId={userId} photo={photo} type={hasTags ? 'large' : photoType ?? type} />
+        <ProfilePhoto userId={userId} photo={photo} type={type} />
         <Pad size={spacings.xs} />
-        <View style={{ flexDirection: 'column' }}>
-            <View style={oneLine ? {flexDirection: 'row' } : {flexDirection: 'column'}}>
-                {clickable ?
-                    <TextButton type='small' strong text={name ?? persona?.name} underline={underline} onPress={onProfile} />
-                :
-                    <UtilityText weight='medium' text={name ?? persona?.name} underline={underline} />
-                }
-                <Pad size={oneLine ? 8 : 4} />
-                {time && <UtilityText color={colorTextGrey}
-                    label={'{time}' + (edited ? (' • ' + (oneLine ? 'edited' : 'Edited')) : '')}
-                    formatParams={oneLine ? { time: formatMiniDate(time, language) } : { time: formatDate(time, language) } } underline={underline} />
-                }
-            </View>
-            {hasTags && <PadBox top={4}><TagRow tags={tags} /></PadBox>}
+        <View style={{ flexDirection: type === 'abbreviated' ? 'row' : 'column' }}>
+            {clickable ?
+                <TextButton type='small' strong text={name ?? persona?.name} underline={underline} onPress={onProfile} />
+            :
+                <UtilityText weight='medium' text={name ?? persona?.name} underline={underline} />
+            }
+            <Pad size={type === 'abbreviated' ? 6 : 2} />
+            <BylineMetaData userId={userId} time={time} edited={edited} abbreviated={type == 'abbreviated'}/>
         </View>
     </View>
 }
-
 
 const BylineStyle = StyleSheet.create({
     outer: {
@@ -241,6 +242,7 @@ const sizeMap = {
     large: 40,
     small: 32,
     tiny: 24,
+    abbreviated: 24,
 }
 
 const checkPadMap = {

--- a/client/component/topbar.js
+++ b/client/component/topbar.js
@@ -254,7 +254,7 @@ function UserInfo() {
                     {showBetaTag && <PadBox right={12}> 
                         <BetaTag /> 
                     </PadBox>}                    
-                    <Byline userId={personaKey} clickable={false} name={persona.name} underline={hover} />
+                    <Byline userId={personaKey} clickable={false} name={persona.name} underline={hover} showMetadata={false} />
                     <Pad size={8} />
                     {shown ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
                 </HorizBox>

--- a/client/demo/designsystem-demo.js
+++ b/client/demo/designsystem-demo.js
@@ -184,15 +184,18 @@ function ProfileScreen() {
                 <Byline userId={'g'} type='small' photoType='large' time={Date.now()} />
                 <Byline userId='x' type='small' photoType='large' time={Date.now()} />
                 <Byline userId='z' type='small' photoType='large' time={Date.now()} />
+                <Byline userId='x' type='tiny' photoType='large' time={Date.now()} />
+                <Byline userId='z' type='tiny' photoType='large' time={Date.now()} />
+                <Byline userId='x' type='abbreviated' photoType='large' time={Date.now()} />
+                <Byline userId='z' type='abbreviated' photoType='large' time={Date.now()} />
                 <Datastore config={{bylineTags:[
                         () => <Tag type='tiny' label='Awesome Person'/>,
-                        (persona) => persona.key == 'b' && <Tag type='tiny' label='Superhero'/>,
                     ]}}>
                     <Byline userId='a' type='large' time={Date.now()} />
                     <Pad />
                     <Byline userId='b' type='large' time={Date.now()} edited={Date.now()} />
                     <Pad />
-                    <Byline userId='a' type='small' time={Date.now()} />
+                    <Byline userId='b' type='abbreviated' time={Date.now() - 1000 * 60 * 60 * 10} />
                 </Datastore>
 
             </DemoSection>

--- a/client/demo/designsystem-demo.js
+++ b/client/demo/designsystem-demo.js
@@ -180,7 +180,7 @@ function ProfileScreen() {
                 <Datastore config={{bylineTags:[
                         () => <Tag type='tiny' label='Awesome Person'/>,
                     ]}}>
-                    <Byline userId='a' type='large' time={Date.now()} />
+                    <Byline userId='a' type='large' />
                     <Pad />
                     <Byline userId='b' type='large' time={Date.now()} edited={Date.now()} />
                 </Datastore>                

--- a/client/demo/designsystem-demo.js
+++ b/client/demo/designsystem-demo.js
@@ -180,14 +180,12 @@ function ProfileScreen() {
                 <Byline userId={'c'} type='small' time={Date.now()} />
                 <Byline userId={'d'} type='small' />
                 <Byline userId={'e'} type='small' time={Date.now()} edited={Date.now()} />
-                <Byline userId={'f'} type='small' photoType='large' />
-                <Byline userId={'g'} type='small' photoType='large' time={Date.now()} />
-                <Byline userId='x' type='small' photoType='large' time={Date.now()} />
-                <Byline userId='z' type='small' photoType='large' time={Date.now()} />
-                <Byline userId='x' type='tiny' photoType='large' time={Date.now()} />
-                <Byline userId='z' type='tiny' photoType='large' time={Date.now()} />
-                <Byline userId='x' type='abbreviated' photoType='large' time={Date.now()} />
-                <Byline userId='z' type='abbreviated' photoType='large' time={Date.now()} />
+                <Byline userId='x' type='small' time={Date.now()} />
+                <Byline userId='z' type='small' time={Date.now()} />
+                <Byline userId='x' type='tiny' time={Date.now()} />
+                <Byline userId='z' type='tiny' time={Date.now()} />
+                <Byline userId='x' type='abbreviated' time={Date.now()} />
+                <Byline userId='z' type='abbreviated' time={Date.now()} />
                 <Datastore config={{bylineTags:[
                         () => <Tag type='tiny' label='Awesome Person'/>,
                     ]}}>
@@ -204,8 +202,6 @@ function ProfileScreen() {
                 <Byline name='Anonymous User' type='large' time={Date.now() - 1000 * 60 * 10} edited={Date.now()} />
                 <Byline name='Anonymous User' type='small' time={Date.now()} />
                 <Byline name='Anonymous User' type='small' />
-                <Byline name='Anonymous User' photoType='large' type='small' time={Date.now()} />
-                <Byline name='Anonymous User' photoType='large' type='small' />
             </DemoSection>
             <DemoSection label='Letter face' horiz>
                 <LetterFace name='dave' type='huge' hue={183} />

--- a/client/demo/designsystem-demo.js
+++ b/client/demo/designsystem-demo.js
@@ -187,7 +187,7 @@ function ProfileScreen() {
             </DemoSection>
             <DemoSection label='Byline - Small'>
                 <Byline userId={'c'} type='small' time={Date.now()} />
-                <Byline userId={'d'} type='small' />
+                <Byline userId={'d'} type='small' showMetadata={false} />
                 <Byline userId={'e'} type='small' time={Date.now()} edited={Date.now()} />
                 <Byline userId='x' type='small' time={Date.now()} />
                 <Byline userId='z' type='small' time={Date.now()} />
@@ -195,16 +195,6 @@ function ProfileScreen() {
             <DemoSection label='Byline - Tiny'>
                 <Byline userId='x' type='tiny' time={Date.now()} />
                 <Byline userId='z' type='tiny' time={Date.now()} />
-            </DemoSection>
-            <DemoSection label='Byline - Abbreviated'>
-                <Byline userId='x' type='abbreviated' time={Date.now()} />
-                <Byline userId='z' type='abbreviated' time={Date.now()} />
-                <Datastore config={{bylineTags:[
-                        () => <Tag type='tiny' label='Awesome Person'/>,
-                    ]}}>
-                    <Byline userId='b' type='abbreviated' time={Date.now() - 1000 * 60 * 60 * 10} />
-                </Datastore>
-
             </DemoSection>
             <DemoSection label='Anonymous'>
                 <Byline name='Anonymous User' type='large' time={Date.now()} />

--- a/client/demo/designsystem-demo.js
+++ b/client/demo/designsystem-demo.js
@@ -173,26 +173,35 @@ function ProfileScreen() {
                 <FacePile userIdList={['a','b','c','z']} type='small' />
                 <FacePile userIdList={['x','d','e','f','g','h','i','j']} type='tiny' />
             </DemoSection>
-            <DemoSection label='Byline'>
+            <DemoSection label='Byline - Large'>
                 <Byline userId={'a'} type='large' time={Date.now()} />
                 <Byline userId={'b'} type='large' time={Date.now() - 1000 * 60 * 10} edited={Date.now()} />
                 <Byline userId={'y'} type='large' time={Date.now() - 1000 * 60 * 60 * 10} edited={Date.now()} />
-                <Byline userId={'c'} type='small' time={Date.now()} />
-                <Byline userId={'d'} type='small' />
-                <Byline userId={'e'} type='small' time={Date.now()} edited={Date.now()} />
-                <Byline userId='x' type='small' time={Date.now()} />
-                <Byline userId='z' type='small' time={Date.now()} />
-                <Byline userId='x' type='tiny' time={Date.now()} />
-                <Byline userId='z' type='tiny' time={Date.now()} />
-                <Byline userId='x' type='abbreviated' time={Date.now()} />
-                <Byline userId='z' type='abbreviated' time={Date.now()} />
                 <Datastore config={{bylineTags:[
                         () => <Tag type='tiny' label='Awesome Person'/>,
                     ]}}>
                     <Byline userId='a' type='large' time={Date.now()} />
                     <Pad />
                     <Byline userId='b' type='large' time={Date.now()} edited={Date.now()} />
-                    <Pad />
+                </Datastore>                
+            </DemoSection>
+            <DemoSection label='Byline - Small'>
+                <Byline userId={'c'} type='small' time={Date.now()} />
+                <Byline userId={'d'} type='small' />
+                <Byline userId={'e'} type='small' time={Date.now()} edited={Date.now()} />
+                <Byline userId='x' type='small' time={Date.now()} />
+                <Byline userId='z' type='small' time={Date.now()} />
+            </DemoSection>
+            <DemoSection label='Byline - Tiny'>
+                <Byline userId='x' type='tiny' time={Date.now()} />
+                <Byline userId='z' type='tiny' time={Date.now()} />
+            </DemoSection>
+            <DemoSection label='Byline - Abbreviated'>
+                <Byline userId='x' type='abbreviated' time={Date.now()} />
+                <Byline userId='z' type='abbreviated' time={Date.now()} />
+                <Datastore config={{bylineTags:[
+                        () => <Tag type='tiny' label='Awesome Person'/>,
+                    ]}}>
                     <Byline userId='b' type='abbreviated' time={Date.now() - 1000 * 60 * 60 * 10} />
                 </Datastore>
 


### PR DESCRIPTION
Updates byline according to the design here:
https://www.figma.com/design/MX0AcO8d0ZlCBs4e9vkl5f/PSI-Design-System?node-id=1102-2973&node-type=canvas&t=lMi5QZ4jNrhUGlmy-0

Three variants: Large, Small, Tiny
All metadata shows on the second line
Metadata row is toggleable

Confirmed with Tori these are desired sizes configurations for ByLines across the app:

Comment preview (ie your current response): Small
Immediately above the composer: Large
Question Author byline: large 
Top post in Comment thread - large
Reply in comment thread - small
Reply to a reply in a comment thread - tiny
Comment reply composer - small (no metadata shown)
Top Bar: small (no metadata shown)
Teaser comment preview: small 